### PR TITLE
add flag recent_days

### DIFF
--- a/src/bin/choctaw_hog.rs
+++ b/src/bin/choctaw_hog.rs
@@ -88,7 +88,10 @@ fn run(arg_matches: &ArgMatches) -> Result<(), SimpleError> {
     let since_commit = arg_matches.value_of("SINCECOMMIT");
     let until_commit = arg_matches.value_of("UNTILCOMMIT");
     let scan_entropy = arg_matches.is_present("ENTROPY");
-    let recent_days = value_t!(arg_matches.value_of("RECENTDAYS"), u32).unwrap_or(0);
+    let recent_days: Option<u32> = match value_t!(arg_matches.value_of("RECENTDAYS"), u32) {
+        Ok(d) => { if d <= 0 { None } else { Some(d) } },
+        Err(e) => None
+    };
 
     // Get Git objects
     let dest_dir = TempDir::new("rusty_hogs").unwrap();

--- a/src/bin/choctaw_hog.rs
+++ b/src/bin/choctaw_hog.rs
@@ -13,6 +13,7 @@
 //!    -V, --version            Prints version information
 //!
 //!OPTIONS:
+//!        --recent_days <RECENTDAYS>       Filters commits to the last number of days (branch agnostic)
 //!        --httpspass <HTTPSPASS>          Takes a password for HTTPS-based authentication
 //!        --httpsuser <HTTPSUSER>          Takes a username for HTTPS-based authentication
 //!    -o, --outputfile <OUTPUT>            Sets the path to write the scanner results to (stdout by default)
@@ -64,6 +65,7 @@ fn main() {
         (@arg SSHKEYPHRASE: --sshkeyphrase +takes_value "Takes a passphrase to a private SSH key for git authentication, defaults to none")
         (@arg HTTPSUSER: --httpsuser +takes_value "Takes a username for HTTPS-based authentication")
         (@arg HTTPSPASS: --httpspass +takes_value "Takes a password for HTTPS-based authentication")
+        (@arg RECENTDAYS: --recent_days +takes_value conflicts_with[SINCECOMMIT] "Filters commits to the last number of days (branch agnostic)")
     )
     .get_matches();
     match run(&matches) {
@@ -86,6 +88,7 @@ fn run(arg_matches: &ArgMatches) -> Result<(), SimpleError> {
     let since_commit = arg_matches.value_of("SINCECOMMIT");
     let until_commit = arg_matches.value_of("UNTILCOMMIT");
     let scan_entropy = arg_matches.is_present("ENTROPY");
+    let recent_days = value_t!(arg_matches.value_of("RECENTDAYS"), u32).unwrap_or(0);
 
     // Get Git objects
     let dest_dir = TempDir::new("rusty_hogs").unwrap();
@@ -101,7 +104,7 @@ fn run(arg_matches: &ArgMatches) -> Result<(), SimpleError> {
         httpsuser,
         httpspass,
     );
-    let findings = git_scanner.perform_scan(None, since_commit, until_commit, scan_entropy);
+    let findings = git_scanner.perform_scan(None, since_commit, until_commit, scan_entropy, recent_days);
 
     // Output the results
     info!("Found {} secrets", findings.len());

--- a/src/git_scanning.rs
+++ b/src/git_scanning.rs
@@ -38,7 +38,7 @@
 //! let gs = GitScanner::new();
 //!
 //! let mut gs = gs.init_git_repo(".", Path::new("."), None, None, None, None);
-//! let findings: HashSet<GitFinding> = gs.perform_scan(None, None, Some("8013160e"), false);
+//! let findings: HashSet<GitFinding> = gs.perform_scan(None, None, Some("8013160e"), false, None);
 //! assert_eq!(findings.len(), 45);
 //! ```
 
@@ -109,7 +109,7 @@ impl GitScanner {
         since_commit: Option<&str>,
         until_commit: Option<&str>,
         scan_entropy: bool,
-        recent_days: u32,
+        recent_days: Option<u32>,
     ) -> HashSet<GitFinding> {
         let repo_option = self.repo.as_ref(); //borrowing magic here!
         let repo = repo_option.unwrap();
@@ -131,10 +131,9 @@ impl GitScanner {
                 o.as_commit().unwrap().time()
             }
             None =>  {
-                if recent_days > 0 {
-                    Time::new( Utc::now().timestamp() - (recent_days as i64 * 24 * 60 * 60), 0)
-                } else {
-                    Time::new(0,0)
+                match recent_days {
+                    Some(rd) => Time::new(Utc::now().timestamp() - (rd as i64 * 24 * 60 * 60), 0),
+                    None => Time::new(0, 0)
                 }
             }
         };


### PR DESCRIPTION
Added the flag `recent_days` to only check commits to the repo in the last number of days. This lets us run a scan against only new commits while not requiring us to keep state of the last scanned commit (or look it up prior to the scan to pass it in). This can only be used if `since_commit` is not also specified.

My first PR to a Rust project, so sorry if I missed anything. Thanks for creating this! The speed of this implementation lets us get through so many more repos. 💨 