### PR TITLE
fixed #16 Refactored duroc_hog to avoid output file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 
 ## v0.4.5 
 - Initial entry, includes refactor from v0.4.4 and latest regex changes.
+
+## v1.0.7
+- duroc_hog no longer scans the output file when repeatedly scanning a directory.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_hogs"
-version = "1.0.5"
+version = "1.0.7"
 authors = ["Scott Cutler <scutler@newrelic.com>"]
 edition = "2018"
 description = "This project provides a set of scanners that will use regular expressions to try and detect the presence of sensitive information such as API keys, passwords, and personal information. It includes a set of regular expressions by default, but will also accept a JSON object containing your custom regular expressions."
@@ -47,3 +47,6 @@ tar = "0.4.26"
 flate2 = "1.0.14"
 anyhow = "1.0"
 tempfile = "^3.1"
+
+[dev-dependencies]
+escargot = "0.5.0"


### PR DESCRIPTION
This PR is duplicated in PR #19 

Fixes #16 

# What

This PR adds an `output_file` argument to the private `scan_dir` function in `duroc_hog`, and refactors the `scan_dir` function to repeat less code and separate directory iteration approaches from file scanning, resulting in less repeating code. 

By filtering the files in the scanned directory, these changes avoid scanning `duroc_hog`'s output file, avoiding false finds after repeated runs.

# Testing

An integration test for the `duroc_hog` has been included. The binary build does slow the tests down somewhat, and escargot has been included as a dev-dependency. 