### PR TITLE
Add whitelist to duroc hog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,9 @@
 
 ## v0.4.5 
 - Initial entry, includes refactor from v0.4.4 and latest regex changes.
+
+## v1.0.7
+- duroc_hog no longer scans the output file when repeatedly scanning a directory.
+
+## v1.1.7
+- duroc_hog takes an optional whitelist argument.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_hogs"
-version = "1.0.5"
+version = "1.1.7"
 authors = ["Scott Cutler <scutler@newrelic.com>"]
 edition = "2018"
 description = "This project provides a set of scanners that will use regular expressions to try and detect the presence of sensitive information such as API keys, passwords, and personal information. It includes a set of regular expressions by default, but will also accept a JSON object containing your custom regular expressions."
@@ -47,3 +47,6 @@ tar = "0.4.26"
 flate2 = "1.0.14"
 anyhow = "1.0"
 tempfile = "^3.1"
+
+[dev-dependencies]
+escargot = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tar = "0.4.26"
 flate2 = "1.0.14"
 anyhow = "1.0"
 tempfile = "^3.1"
+path-clean = "0.1.0"
 
 [dev-dependencies]
 escargot = "0.5.0"

--- a/src/bin/ankamali_hog.rs
+++ b/src/bin/ankamali_hog.rs
@@ -44,7 +44,7 @@ use rusty_hogs::{SecretScanner, SecretScannerBuilder};
 /// Main entry function that uses the [clap crate](https://docs.rs/clap/2.33.0/clap/)
 fn main() {
     let matches = clap_app!(ankamali_hog =>
-        (version: "1.0.5")
+        (version: "1.1.7")
         (author: "Scott Cutler <scutler@newrelic.com>")
         (about: "Google Drive secret scanner in Rust.")
         (@arg REGEX: --regex +takes_value "Sets a custom regex JSON file")

--- a/src/bin/berkshire_hog.rs
+++ b/src/bin/berkshire_hog.rs
@@ -45,7 +45,7 @@ use std::iter::FromIterator;
 /// Main entry function that uses the [clap crate](https://docs.rs/clap/2.33.0/clap/)
 fn main() {
     let matches = clap_app!(berkshire_hog =>
-        (version: "1.0.5")
+        (version: "1.1.7")
         (author: "Scott Cutler <scutler@newrelic.com>")
         (about: "S3 secret hunter in Rust. Avoid bandwidth costs, run this within a VPC!")
         (@arg REGEX: --regex +takes_value "Sets a custom regex JSON file")

--- a/src/bin/choctaw_hog.rs
+++ b/src/bin/choctaw_hog.rs
@@ -15,6 +15,7 @@
 //!    -V, --version            Prints version information
 //!
 //!OPTIONS:
+//!    -w, --whitelist <WHITELIST>          Sets a custom whitelist JSON file
 //!        --recent_days <RECENTDAYS>       Filters commits to the last number of days (branch agnostic)
 //!        --match_entropy_threshold <MATCH_ENTROPY_THRESHOLD>    Threshold for match entropy (4.5 by default)
 //!        --httpspass <HTTPSPASS>          Takes a password for HTTPS-based authentication
@@ -52,7 +53,7 @@ use rusty_hogs::{SecretScanner, SecretScannerBuilder};
 /// Main entry function that uses the [clap crate](https://docs.rs/clap/2.33.0/clap/)
 fn main() {
     let matches = clap_app!(choctaw_hog =>
-        (version: "1.0.5")
+        (version: "1.1.7")
         (author: "Scott Cutler <scutler@newrelic.com>")
         (about: "Git secret scanner in Rust")
         (@arg REGEX: -r --regex +takes_value "Sets a custom regex JSON file")

--- a/src/bin/duroc_hog.rs
+++ b/src/bin/duroc_hog.rs
@@ -47,7 +47,7 @@ use encoding::all::ASCII;
 use encoding::{DecoderTrap, Encoding};
 use rusty_hogs::{SecretScanner, SecretScannerBuilder};
 use std::collections::HashSet;
-use path_clean::{clean, PathClean};
+use path_clean::PathClean;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Default)]
 /// `serde_json` object that represents a single found secret - finding

--- a/src/bin/duroc_hog.rs
+++ b/src/bin/duroc_hog.rs
@@ -352,7 +352,7 @@ mod tests {
 
         write_temp_file(&temp_dir, "insecure-file.txt", "My email is username@mail.com");
 
-        let cmd_args = ["-o", "./output_file.txt", "."];
+        let cmd_args = ["-o", "output_file.txt", "."];
 
         run_command_in_dir(&temp_dir, "duroc_hog", &cmd_args).unwrap();
 

--- a/src/bin/duroc_hog.rs
+++ b/src/bin/duroc_hog.rs
@@ -15,6 +15,7 @@
 //!    -V, --version            Prints version information
 //!
 //!OPTIONS:
+//!    -w, --whitelist <WHITELIST>          Sets a custom whitelist JSON file
 //!    -o, --outputfile <OUTPUT>            Sets the path to write the scanner results to (stdout by default)
 //!    -r, --regex <REGEX>                  Sets a custom regex JSON file, defaults to built-in
 
@@ -66,7 +67,7 @@ const GZEXTENSIONS: &[&str] = &["gz", "tgz"];
 /// Main entry function that uses the [clap crate](https://docs.rs/clap/2.33.0/clap/)
 fn main() {
     let matches = clap_app!(duroc_hog =>
-        (version: "1.0.5")
+        (version: "1.1.7")
         (author: "Scott Cutler <scutler@newrelic.com>")
         (about: "File system secret scanner in Rust")
         (@arg REGEX: -r --regex +takes_value "Sets a custom regex JSON file")
@@ -78,6 +79,7 @@ fn main() {
         (@arg CASE: --caseinsensitive "Sets the case insensitive flag for all regexes")
         (@arg OUTPUT: -o --outputfile +takes_value "Sets the path to write the scanner results to (stdout by default)")
         (@arg PRETTYPRINT: --prettyprint "Outputs the JSON in human readable format")
+        (@arg WHITELIST: -w --whitelist +takes_value "Sets a custom whitelist JSON file")
     )
         .get_matches();
     match run(&matches) {
@@ -96,6 +98,7 @@ fn run(arg_matches: &ArgMatches) -> Result<(), SimpleError> {
     // let scan_entropy = arg_matches.is_present("ENTROPY");
     let recursive = arg_matches.is_present("RECURSIVE");
     let fspath = Path::new(arg_matches.value_of("FSPATH").unwrap());
+    let output_file = Path::new(arg_matches.value_of("OUTPUT").unwrap_or(""));
     let unzip: bool = arg_matches.is_present("UNZIP");
 
     debug!("fspath: {:?}", fspath);
@@ -110,7 +113,7 @@ fn run(arg_matches: &ArgMatches) -> Result<(), SimpleError> {
     let mut output: HashSet<FileFinding> = HashSet::new();
 
     if Path::is_dir(fspath) {
-        output.extend(scan_dir(fspath, &secret_scanner, recursive, unzip));
+        output.extend(scan_dir(fspath, output_file, &secret_scanner, recursive, unzip));
     } else {
         let f = File::open(fspath).unwrap();
         output.extend(scan_file(fspath, &secret_scanner, f, "", unzip));
@@ -125,42 +128,60 @@ fn run(arg_matches: &ArgMatches) -> Result<(), SimpleError> {
 
 fn scan_dir(
     fspath: &Path,
+    output_file: &Path,
     ss: &SecretScanner,
     recursive: bool,
     unzip: bool,
 ) -> HashSet<FileFinding> {
     let mut output: HashSet<FileFinding> = HashSet::new();
-    if recursive {
-        for entry in WalkDir::new(fspath).into_iter().filter_map(|e| e.ok()) {
-            if entry.file_type().is_file() {
-                let f = File::open(entry.path()).unwrap();
-                let mut inner_findings = scan_file(entry.path(), &ss, f, "", unzip);
-                for d in inner_findings.drain() {
-                    output.insert(d);
-                }
-            }
-        }
+
+    let dir_scan_func = if recursive {
+        recursive_dir_scan
     } else {
-        let dir_contents: Vec<PathBuf> = fspath
+        flat_dir_scan
+    };
+
+    dir_scan_func(fspath, Path::new(output_file), |file_path: &Path| {
+        let f = File::open(file_path).unwrap();
+        let mut inner_findings = scan_file(file_path, &ss, f, "", unzip);
+        for d in inner_findings.drain() {
+            output.insert(d);
+        }
+    });
+
+    output
+}
+
+fn recursive_dir_scan<C>(
+    fspath: &Path,
+    output_file: &Path,
+    mut closure: C
+) where C: FnMut(&Path) {
+    for entry in WalkDir::new(fspath).into_iter().filter_map(|e| e.ok()) {
+        if entry.file_type().is_file() && entry.path() != output_file {
+            closure(&entry.path());
+        }
+    }
+}
+
+fn flat_dir_scan<C>(
+    fspath: &Path,
+    output_file: &Path,
+    mut closure: C
+) where C: FnMut(&Path) {
+    let dir_contents: Vec<PathBuf> = fspath
             .read_dir()
             .expect("read_dir call failed")
             .filter_map(|e| e.ok())
             .filter(|e| e.file_type().unwrap().is_file())
             .map(|e| e.path())
+            .filter(|e| e != output_file)
             .collect();
-        debug!("dir_contents: {:?}", dir_contents);
-        for file_path in dir_contents {
-            let path = file_path.clone();
-            let f = File::open(file_path).unwrap();
-            let mut inner_findings = scan_file(&path, &ss, f, "", unzip);
-            for d in inner_findings.drain() {
-                info!("FileFinding: {:?}", d);
-                output.insert(d);
-            }
-            debug!("inner findings: {:?}", inner_findings);
-        }
+    debug!("dir_contents: {:?}", dir_contents);
+
+    for file_path in dir_contents {
+        closure(&file_path);
     }
-    output
 }
 
 fn scan_file<R: Read + io::Seek>(
@@ -198,7 +219,9 @@ fn scan_file<R: Read + io::Seek>(
             );
             for d in inner_findings.drain() {
                 info!("FileFinding: {:?}", d);
-                findings.insert(d);
+                if !&ss.is_whitelisted(d.reason.as_str(), &(d.strings_found)) {
+                    findings.insert(d);
+                }
             }
         }
         findings
@@ -220,7 +243,9 @@ fn scan_file<R: Read + io::Seek>(
             );
             for d in inner_findings.drain() {
                 info!("FileFinding: {:?}", d);
-                findings.insert(d);
+                if !&ss.is_whitelisted(d.reason.as_str(), &(d.strings_found)) {
+                    findings.insert(d);
+                }
             }
         }
         findings
@@ -245,7 +270,9 @@ fn scan_file<R: Read + io::Seek>(
         );
         for d in inner_findings.drain() {
             info!("FileFinding: {:?}", d);
-            findings.insert(d);
+            if !&ss.is_whitelisted(d.reason.as_str(), &(d.strings_found)) {
+                findings.insert(d);
+            }
         }
         findings
     } else {
@@ -272,7 +299,7 @@ fn scan_bytes(input: Vec<u8>, ss: &SecretScanner, path: String) -> HashSet<FileF
                     .unwrap_or_else(|_| "<STRING DECODE ERROR>".parse().unwrap());
                 strings_found.push(result);
             }
-            if !strings_found.is_empty() {
+            if !strings_found.is_empty() && !ss.is_whitelisted(r.as_str(), &strings_found) {
                 let new_line_string = ASCII
                     .decode(&new_line, DecoderTrap::Ignore)
                     .unwrap_or_else(|_| "<STRING DECODE ERROR>".parse().unwrap());
@@ -287,4 +314,83 @@ fn scan_bytes(input: Vec<u8>, ss: &SecretScanner, path: String) -> HashSet<FileF
         }
     }
     findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Result;
+    use std::process::Output;
+    use std::io::Write;
+    use tempfile::{NamedTempFile, TempDir};
+    use escargot::CargoBuild;
+
+    fn run_command_in_dir(dir: &TempDir, command: &str, args: &[&str]) -> Result<Output> {
+        let dir_path = dir.path().to_str().unwrap();
+        let binary = CargoBuild::new()
+            .bin(command)
+            .run()
+            .unwrap();
+
+        binary.command()
+            .current_dir(dir_path)
+            .args(args)
+            .output()
+    }
+
+    fn write_temp_file(dir: &TempDir, filename: &str, contents: &str) {
+        let file_path = dir.path().join(filename);
+        let mut tmp_file = File::create(&file_path).unwrap();
+        write!(tmp_file, "{}", contents).unwrap();
+    }
+
+    fn read_temp_file(dir: &TempDir, filename: &str) -> String {
+        let mut contents = String::new();
+        let file_path = dir.path().join(filename);
+        let mut file_handle = File::open(&file_path).unwrap();
+        file_handle.read_to_string(&mut contents).unwrap();
+        contents
+    }
+
+    #[test]
+    fn does_not_scan_output_file() {
+        let temp_dir = TempDir::new().unwrap();
+
+        write_temp_file(&temp_dir, "insecure-file.txt", "My email is username@mail.com");
+
+        let cmd_args = ["-o", "./output_file.txt", "."];
+
+        run_command_in_dir(&temp_dir, "duroc_hog", &cmd_args).unwrap();
+
+        run_command_in_dir(&temp_dir, "duroc_hog", &cmd_args).unwrap();
+
+        let text = read_temp_file(&temp_dir, "output_file.txt");
+
+        println!("{}", text);
+
+        assert!(text.contains("\"path\":\"./insecure-file.txt\""));
+        assert!(!text.contains("output_file.txt"));
+    }
+
+    #[test]
+    fn whitelist_json_file_prevents_output() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut whitelist_temp_file = NamedTempFile::new().unwrap();
+        let json = r#"
+        {
+            "Email address": [
+                "username@mail.com"
+            ]
+        }
+        "#;
+        write!(whitelist_temp_file, "{}", json).unwrap();
+        write_temp_file(&temp_dir, "insecure-file.txt", "My email is username@mail.com");
+
+        let cmd_args = ["--whitelist", whitelist_temp_file.path().to_str().unwrap(), "."];
+
+        let output = run_command_in_dir(&temp_dir, "duroc_hog", &cmd_args).unwrap();
+
+        assert_eq!("[]\n", str::from_utf8(&output.stdout).unwrap());
+
+    }
 }

--- a/src/bin/gottingen_hog.rs
+++ b/src/bin/gottingen_hog.rs
@@ -62,7 +62,7 @@ pub struct JiraFinding {
 /// Main entry function that uses the [clap crate](https://docs.rs/clap/2.33.0/clap/)
 fn main() {
     let matches = clap_app!(gottingen_hog =>
-        (version: "1.0.1")
+        (version: "1.1.7")
         (author: "Emily Cain <ecain@newrelic.com>")
         (about: "Jira secret scanner in Rust.")
         (@arg REGEX: --regex +takes_value "Sets a custom regex JSON file")


### PR DESCRIPTION
Fixes #15 
Fixes #16 

# What

This PR adds an `output_file` argument to the private `scan_dir` function in `duroc_hog`, and refactors the `scan_dir` function to repeat less code and separate directory iteration approaches from file scanning, resulting in less repeating code. 

By filtering the files in the scanned directory, these changes avoid scanning `duroc_hog`'s output file, avoiding false finds after repeated runs.

This PR also adds a whitelist option to `duroc_hog` by using the SecretScanner's `is_whitelisted` method inside the `scan_file` and `scan_bytes` functions

# Testing

Integration tests for `duroc_hog` have been included. The binary build does slow the tests down somewhat, and escargot has been included as a dev-dependency. 