### PR TITLE
Essex Hog: Removed hard-coded context from Confluence URL

### DIFF
--- a/src/bin/essex_hog.rs
+++ b/src/bin/essex_hog.rs
@@ -170,9 +170,10 @@ fn get_page(
     base_url: &str,
     page_id: &str,
 ) -> ConfluencePage {
+    let base_url_trimmed = base_url.trim_end_matches('/');
     let page_full_url = format!(
         "{}/rest/api/content/{}?expand=body.storage",
-        base_url, page_id
+        base_url_trimmed, page_id
     );
     let json_results = get_json(&client, &auth_headers, &page_full_url);
     let body = json_results
@@ -192,11 +193,11 @@ fn get_page(
         .as_str()
         .unwrap()
         .trim_start_matches('/');
-    let web_link = format!("{}/{}", base_url, webui);
+    let web_link = format!("{}/{}", base_url_trimmed, webui);
 
     let comments_full_url = format!(
         "{}/rest/api/content/{}/child/comment?expand=body.storage",
-        base_url, page_id
+        base_url_trimmed, page_id
     );
     let json_results = get_json(&client, &auth_headers, &comments_full_url);
     let comments = json_results.get("results").unwrap();

--- a/src/bin/essex_hog.rs
+++ b/src/bin/essex_hog.rs
@@ -22,6 +22,12 @@
 //! ARGS:
 //!     <PAGEID>    The ID (e.g. 1234) of the confluence page you want to scan
 //!     <URL>       Base URL of Confluence instance (e.g. https://newrelic.atlassian.net/)
+//! 				From https://docs.atlassian.com/ConfluenceServer/rest/7.11.0/ Structure of the REST URIs section
+//! 				for details on declaring the base url with or without context
+//! 				With context: http://host:port/context/rest/api/resource-name
+//! 				Or without context: http://host:port/rest/api/resource-name
+//! 				Example with context: http://example.com:8080/confluence/rest/api/space/ds
+//! 				Example without context: http://confluence.myhost.com:8095/rest/api/space/ds
 
 #[macro_use]
 extern crate clap;
@@ -165,7 +171,7 @@ fn get_page(
     page_id: &str,
 ) -> ConfluencePage {
     let page_full_url = format!(
-        "{}wiki/rest/api/content/{}?expand=body.storage",
+        "{}rest/api/content/{}?expand=body.storage",
         base_url, page_id
     );
     let json_results = get_json(&client, &auth_headers, &page_full_url);
@@ -186,10 +192,10 @@ fn get_page(
         .as_str()
         .unwrap()
         .trim_start_matches('/');
-    let web_link = format!("{}wiki/{}", base_url, webui);
+    let web_link = format!("{}", base_url, webui);
 
     let comments_full_url = format!(
-        "{}wiki/rest/api/content/{}/child/comment?expand=body.storage",
+        "{}rest/api/content/{}/child/comment?expand=body.storage",
         base_url, page_id
     );
     let json_results = get_json(&client, &auth_headers, &comments_full_url);

--- a/src/bin/essex_hog.rs
+++ b/src/bin/essex_hog.rs
@@ -171,7 +171,7 @@ fn get_page(
     page_id: &str,
 ) -> ConfluencePage {
     let page_full_url = format!(
-        "{}rest/api/content/{}?expand=body.storage",
+        "{}/rest/api/content/{}?expand=body.storage",
         base_url, page_id
     );
     let json_results = get_json(&client, &auth_headers, &page_full_url);
@@ -192,10 +192,10 @@ fn get_page(
         .as_str()
         .unwrap()
         .trim_start_matches('/');
-    let web_link = format!("{}", base_url, webui);
+    let web_link = format!("{}/{}", base_url, webui);
 
     let comments_full_url = format!(
-        "{}rest/api/content/{}/child/comment?expand=body.storage",
+        "{}/rest/api/content/{}/child/comment?expand=body.storage",
         base_url, page_id
     );
     let json_results = get_json(&client, &auth_headers, &comments_full_url);


### PR DESCRIPTION
Based on the Confluence documentation, this change now sets the default to no context when passing in the base URL. If a user is scanning a Confluence instance that uses context, they will need to append it to the base URL to get a correct API endpoint