### PR TITLE
Updated Slack Webhook default rule

### DIFF
--- a/crates/rusty-hog-scanner/src/default_rules.json
+++ b/crates/rusty-hog-scanner/src/default_rules.json
@@ -47,7 +47,7 @@
   "Credentials in absolute URL": "(?i)((https?|ftp)://)(([a-z0-9$_\\.\\+!\\*'\\(\\),;\\?&=-]|%[0-9a-f]{2})+(:([a-z0-9$_\\.\\+!\\*'\\(\\),;\\?&=-]|%[0-9a-f]{2})+)@)((([a-z0-9]\\.|[a-z0-9][a-z0-9-]*[a-z0-9]\\.)*[a-z][a-z0-9-]*[a-z0-9]|((\\d|[1-9]\\d|1\\d{2}|2[0-4][0-9]|25[0-5])\\.){3}(\\d|[1-9]\\d|1\\d{2}|2[0-4][0-9]|25[0-5]))(:\\d+)?)(((/+([a-z0-9$_\\.\\+!\\*'\\(\\),;:@&=-]|%[0-9a-f]{2})*)*(\\?([a-z0-9$_\\.\\+!\\*'\\(\\),;:@&=-]|%[0-9a-f]{2})*)?)?)?",
   "PayPal Braintree Access Token": "(?i)access_token\\$production\\$[0-9a-z]{16}\\$[0-9a-f]{32}",
   "Picatic API Key": "(?i)sk_live_[0-9a-z]{32}",
-  "Slack Webhook": "(?i)https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",
+  "Slack Webhook": "(?i)https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8,10}/[a-zA-Z0-9_]{24}",
   "Stripe API Key": "(?i)sk_live_[0-9a-zA-Z]{24}",
   "Stripe Restricted API Key": "(?i)rk_live_[0-9a-zA-Z]{24}",
   "Square Access Token": "(?i)sq0atp-[0-9A-Za-z\\-_]{22}",


### PR DESCRIPTION
Edited the slack webhook to accept between 8 and 10 characters in the B string.