### PR TITLE
Cleanup Essex_Hog, update authentication docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,13 @@ FLAGS:
 
 OPTIONS:
     -a, --allowlist <ALLOWLIST>                                    Sets a custom allowlist JSON file
-        --authtoken <BEARERTOKEN>                                  Confluence basic auth bearer token (instead of user & pass)
+        --authtoken <BEARERTOKEN>                                  Confluence basic auth bearer token containing a PAT (instead of user & pass)
 
         --default_entropy_threshold <DEFAULT_ENTROPY_THRESHOLD>    Default entropy threshold (0.6 by default)
     -o, --outputfile <OUTPUT>                                      Sets the path to write the scanner results to (stdout by default)
-        --password <PASSWORD>                                      Confluence password (crafts basic auth header)
+        --password <PASSWORD>                                      Confluence password or PAT (crafts basic auth header)
         --regex <REGEX>                                            Sets a custom regex JSON file
-        --username <USERNAME>                                      Confluence username (crafts basic auth header)
+        --username <USERNAME>                                      Confluence username or email address (crafts basic auth header)
 
 ARGS:
     <PAGEID>    The ID (e.g. 1234) of the confluence page you want to scan
@@ -266,13 +266,13 @@ FLAGS:
 
 OPTIONS:
     -a, --allowlist <ALLOWLIST>                                    Sets a custom allowlist JSON file
-        --authtoken <BEARERTOKEN>                                  Jira basic auth bearer token (instead of user & pass)
+        --authtoken <BEARERTOKEN>                                  Jira basic auth bearer token containing a PAT (instead of user & pass)
         --default_entropy_threshold <DEFAULT_ENTROPY_THRESHOLD>    Default entropy threshold (0.6 by default)
         --url <JIRAURL>                                            Base URL of JIRA instance (e.g. https://jira.atlassian.net/)
     -o, --outputfile <OUTPUT>                                      Sets the path to write the scanner results to (stdout by default)
-        --password <PASSWORD>                                      Jira password (crafts basic auth header)
+        --password <PASSWORD>                                      Jira password or PAT (crafts basic auth header)
         --regex <REGEX>                                            Sets a custom regex JSON file
-        --username <USERNAME>                                      Jira username (crafts basic auth header)
+        --username <USERNAME>                                      Jira username or email address (crafts basic auth header)
 
 ARGS:
     <JIRAID>    The ID (e.g. PROJECT-123) of the Jira issue you want to scan

--- a/src/bin/gottingen_hog.rs
+++ b/src/bin/gottingen_hog.rs
@@ -1,4 +1,4 @@
-//! Jira secret scanner in Rust.
+//! JIRA secret scanner in Rust.
 //!
 //! USAGE:
 //!     gottingen_hog [FLAGS] [OPTIONS] <JIRAID> --password <PASSWORD> --username <USERNAME>
@@ -13,11 +13,11 @@
 //!
 //! OPTIONS:
 //!         --default_entropy_threshold <DEFAULT_ENTROPY_THRESHOLD>    Default entropy threshold (0.6 by default)
-//!         --url <JIRAURL>
-//!     -o, --outputfile <OUTPUT>    Sets the path to write the scanner results to (stdout by default)
-//!         --password <PASSWORD>    Jira password (or API token)
-//!         --regex <REGEX>          Sets a custom regex JSON file
-//!         --username <USERNAME>    Jira username
+//!         --authtoken <BEARERTOKEN>    JIRA PAT (instead of user & pass, crafts basic auth header)
+//!     -o, --outputfile <OUTPUT>        Sets the path to write the scanner results to (stdout by default)
+//!         --password <PASSWORD>        JIRA password or PAT (crafts basic auth header)
+//!         --regex <REGEX>              Sets a custom regex JSON file
+//!         --username <USERNAME>        JIRA username or email (crafts basic auth header)
 //!
 //! ARGS:
 //!     <JIRAID>    The ID (e.g. PROJECT-123) of the Jira issue you want to scan
@@ -71,9 +71,9 @@ async fn main() {
         (@arg CASE: --caseinsensitive "Sets the case insensitive flag for all regexes")
         (@arg OUTPUT: -o --outputfile +takes_value "Sets the path to write the scanner results to (stdout by default)")
         (@arg PRETTYPRINT: --prettyprint "Outputs the JSON in human readable format")
-        (@arg USERNAME: --username +takes_value conflicts_with[AUTHTOKEN] "Jira username (crafts basic auth header)")
-        (@arg PASSWORD: --password +takes_value conflicts_with[AUTHTOKEN] "Jira password (crafts basic auth header)")
-        (@arg BEARERTOKEN: --authtoken +takes_value conflicts_with[USERNAME PASSWORD] "Jira basic auth bearer token (instead of user & pass)")
+        (@arg USERNAME: --username +takes_value conflicts_with[AUTHTOKEN] "Jira username or email address (crafts basic auth header)")
+        (@arg PASSWORD: --password +takes_value conflicts_with[AUTHTOKEN] "Jira password or PAT (crafts basic auth header)")
+        (@arg BEARERTOKEN: --authtoken +takes_value conflicts_with[USERNAME PASSWORD] "Jira basic auth bearer token containing a PAT (instead of user & pass)")
         (@arg JIRAURL: --url +takes_value  "Base URL of JIRA instance (e.g. https://jira.atlassian.net/)")
         (@arg ALLOWLIST: -a --allowlist +takes_value "Sets a custom allowlist JSON file")
     )
@@ -112,7 +112,7 @@ async fn run<'b>(arg_matches: ArgMatches<'b>) -> Result<(), SimpleError> {
 
     // TODO: Support other modes of JIRA authentication
     let auth_string = match jirausername {
-        // craft auth header using username and password if present
+        // craft auth header using username and password (or PAT) if present
         Some(u) => {
             format!(
                 "Basic {}",


### PR DESCRIPTION
~~To authenticate to Confluence Server or Datacenter using a PAT (Personal Access Token) (Bearer token), it should NOT be base64 encoded.~~

~~See https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html~~

~~This was already working for JIRA/Gottingenhog, but not yet for Confluence/Essexhog.~~

I also made sure all variables in EssexHog are named `confluencexxxx` to avoid any confusion with GottingenHog.

Ideally the authentication is extracted into a shared piece of code ("atlassian auth"), but since this is my first Rust code change ever, I didn't dare to go that way :-)

Updated docs a little bit as well to help people deciphering the differences between Cloud and Server/Datacenter authentication which are handling the PATs differently.